### PR TITLE
Caixa Economica: Boleto com 7 dígitos

### DIFF
--- a/bopepo/src/main/java/org/jrimum/bopepo/campolivre/CLCaixaEconomicaFederalSIGCB.java
+++ b/bopepo/src/main/java/org/jrimum/bopepo/campolivre/CLCaixaEconomicaFederalSIGCB.java
@@ -143,11 +143,21 @@ class CLCaixaEconomicaFederalSIGCB extends AbstractCLCaixaEconomicaFederal {
 
 		ContaBancaria conta = titulo.getContaBancaria();
 		String nossoNumero = titulo.getNossoNumero();
+		
+		
+		if(conta.getNumeroDaConta().getCodigoDaConta()<=999999) {
+			Integer dVCodigoDoCedente = calculeDigitoVerificador(conta.getNumeroDaConta().getCodigoDaConta().toString());
 
-		Integer dVCodigoDoCedente = calculeDigitoVerificador(conta.getNumeroDaConta().getCodigoDaConta().toString());
-
-		this.add(new FixedField<Integer>(conta.getNumeroDaConta().getCodigoDaConta(), 6, Fillers.ZERO_LEFT));
-		this.add(new FixedField<Integer>(dVCodigoDoCedente, 1));
+			this.add(new FixedField<Integer>(conta.getNumeroDaConta().getCodigoDaConta(), 6, Fillers.ZERO_LEFT));
+			this.add(new FixedField<Integer>(dVCodigoDoCedente, 1));
+		}else { 
+			// Para contas com 7 dígitos //
+			String contaSeteDigitos = conta.getNumeroDaConta().getCodigoDaConta().toString();
+			
+			this.add(new FixedField<Integer>(Integer.valueOf(contaSeteDigitos.substring(0,6)), 6));
+			this.add(new FixedField<Integer>(Integer.valueOf(contaSeteDigitos.substring(6)),1));	
+						
+		}
 		this.add(new FixedField<String>(nossoNumero.substring(0, 3), 3));
 		
 		if(conta.getCarteira().isComRegistro()){

--- a/bopepo/src/test/java/org/jrimum/bopepo/campolivre/TestCLCaixaEconomicaFederalSIGCBSeteDigitos.java
+++ b/bopepo/src/test/java/org/jrimum/bopepo/campolivre/TestCLCaixaEconomicaFederalSIGCBSeteDigitos.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2008 JRimum Project
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+ * applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ * 
+ * Created at: 28/07/2010 - 21:05:00
+ * 
+ * ================================================================================
+ * 
+ * Direitos autorais 2008 JRimum Project
+ * 
+ * Licenciado sob a Licença Apache, Versão 2.0 ("LICENÇA"); você não pode usar
+ * esse arquivo exceto em conformidade com a esta LICENÇA. Você pode obter uma
+ * cópia desta LICENÇA em http://www.apache.org/licenses/LICENSE-2.0 A menos que
+ * haja exigência legal ou acordo por escrito, a distribuição de software sob
+ * esta LICENÇA se dará “COMO ESTÁ”, SEM GARANTIAS OU CONDIÇÕES DE QUALQUER
+ * TIPO, sejam expressas ou tácitas. Veja a LICENÇA para a redação específica a
+ * reger permissões e limitações sob esta LICENÇA.
+ * 
+ * Criado em: 28/07/2010 - 21:05:00
+ * 
+ */
+
+package org.jrimum.bopepo.campolivre;
+
+import org.jrimum.bopepo.BancosSuportados;
+import org.jrimum.domkee.financeiro.banco.febraban.Carteira;
+import org.jrimum.domkee.financeiro.banco.febraban.NumeroDaConta;
+import org.jrimum.domkee.financeiro.banco.febraban.TipoDeCobranca;
+import org.junit.Before;
+
+/**
+ * <p>
+ * Teste unitário do campo livre do banco caixa econômica federal para o serviço SIGCB.
+ * </p>
+ * 
+ * @author <a href="http://gilmatryx.googlepages.com/">Gilmar P.S.L</a>
+ * @author <a href="mailto:romulomail@gmail.com">Rômulo Augusto</a>
+ * 
+ * @since 0.2
+ * 
+ * @version 0.2
+ */
+public class TestCLCaixaEconomicaFederalSIGCBSeteDigitos extends AbstractCampoLivreBaseTest<CLCaixaEconomicaFederalSIGCB> {
+	
+	@Before
+	public void setUp(){
+		
+		titulo.getContaBancaria().setBanco(BancosSuportados.CAIXA_ECONOMICA_FEDERAL.create());
+		titulo.getContaBancaria().setNumeroDaConta(new NumeroDaConta(1234567));
+		titulo.getContaBancaria().setCarteira(new Carteira(24, TipoDeCobranca.COM_REGISTRO));
+		titulo.setNossoNumero("000000000000019");
+		
+		createCampoLivreToTest();
+		
+		setCampoLivreEsperadoComoString("1234567000100040000000197");
+	}
+}


### PR DESCRIPTION
Alteração para gerar boletos com até 7 dígitos no banco da Caixa Econômica Federal